### PR TITLE
feat: add NanoClaw sensor aggregation engine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR /app
-COPY pyproject.toml .
-RUN pip install --no-cache-dir .
+COPY pyproject.toml README.md ./
 COPY src/ src/
+RUN pip install --no-cache-dir .
+
 EXPOSE 8000
-HEALTHCHECK CMD python -c "import httpx; httpx.get('http://localhost:8000/healthz')" || exit 1
+HEALTHCHECK CMD python -c "import httpx; httpx.get('http://localhost:8000/healthz', timeout=5).raise_for_status()" || exit 1
 CMD ["uvicorn", "nanoclaw.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -34,9 +34,59 @@ NanoClaw bridges the gap between the ultra-lightweight PicClaw and the full-feat
 - **Data Collector** — Aggregate sensor data from multiple MicroClaw nodes
 - **Lab Monitor** — Temperature, humidity, air quality with ML anomaly detection
 
+## Raspberry Pi Gateway Quick Start
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+pip install -e ".[dev]"
+nanoclaw --host 0.0.0.0 --port 8000
+```
+
+Docker/ARM64 deployments can use the included multi-arch Python base image:
+
+```bash
+docker build -t nanoclaw:local .
+docker run --rm -p 8000:8000 nanoclaw:local
+```
+
+## Sensor Aggregation API
+
+NanoClaw accepts reports from PicClaw or MicroClaw nodes and keeps a bounded
+in-memory history for each node.
+
+```bash
+curl -X POST http://localhost:8000/api/v1/telemetry \
+  -H 'Content-Type: application/json' \
+  -d '{"node_id":"rack-a1","temperature_c":41.0,"humidity_pct":72.0}'
+```
+
+Core endpoints:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/healthz` | Service health, node count, decision count |
+| `POST` | `/api/v1/telemetry` | Ingest one sensor report |
+| `GET` | `/api/v1/nodes` | List current node states |
+| `GET` | `/api/v1/nodes/{node_id}` | Inspect one node and recent readings |
+| `GET` | `/api/v1/decisions` | List local threshold decisions |
+
+## Local Decision Engine
+
+The first offline decision engine flags temperature and humidity threshold
+crossings without needing MoltClaw/cloud access:
+
+- `temperature_warning`
+- `temperature_critical`
+- `humidity_warning`
+
+Each decision includes the node id, severity, threshold, observed value, and a
+suggested local action such as publishing an alert or dispatching cooling.
+
 ## Status
 
-🚧 **Pre-Alpha** — Architecture design phase. Looking for contributors!
+🚧 **Pre-Alpha** — Sensor aggregation, local threshold decisions, FastAPI
+endpoints, and ARM64-friendly Docker packaging are now scaffolded.
 
 ## Contributing
 

--- a/src/nanoclaw/aggregation.py
+++ b/src/nanoclaw/aggregation.py
@@ -1,0 +1,169 @@
+"""Sensor aggregation and local decisions for NanoClaw."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import time
+from typing import Any
+
+
+@dataclass(slots=True)
+class SensorReading:
+    """A single report from a PicClaw or MicroClaw node."""
+
+    node_id: str
+    temperature_c: float | None = None
+    humidity_pct: float | None = None
+    metrics: dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "temperature_c": self.temperature_c,
+            "humidity_pct": self.humidity_pct,
+            "metrics": self.metrics,
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass(slots=True)
+class NodeState:
+    """Current state and bounded history for one edge node."""
+
+    node_id: str
+    readings: list[SensorReading] = field(default_factory=list)
+    status: str = "unknown"
+    updated_at: float = 0.0
+
+    @property
+    def latest(self) -> SensorReading | None:
+        if not self.readings:
+            return None
+        return self.readings[-1]
+
+    def to_dict(self) -> dict[str, Any]:
+        latest = self.latest
+        return {
+            "node_id": self.node_id,
+            "status": self.status,
+            "updated_at": self.updated_at,
+            "latest": latest.to_dict() if latest else None,
+            "readings": [reading.to_dict() for reading in self.readings],
+        }
+
+
+@dataclass(slots=True)
+class Decision:
+    """A local offline decision generated from sensor data."""
+
+    node_id: str
+    type: str
+    severity: str
+    action: str
+    value: float
+    threshold: float
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "type": self.type,
+            "severity": self.severity,
+            "action": self.action,
+            "value": self.value,
+            "threshold": self.threshold,
+            "timestamp": self.timestamp,
+        }
+
+
+class SensorAggregator:
+    """In-memory L2 sensor aggregator for nearby L1 nodes."""
+
+    def __init__(self, max_readings_per_node: int = 100, stale_after_seconds: int = 120) -> None:
+        self.max_readings_per_node = max_readings_per_node
+        self.stale_after_seconds = stale_after_seconds
+        self._nodes: dict[str, NodeState] = {}
+
+    def ingest(self, reading: SensorReading) -> NodeState:
+        if not reading.node_id:
+            raise ValueError("node_id is required")
+
+        node = self._nodes.setdefault(reading.node_id, NodeState(node_id=reading.node_id))
+        node.readings.append(reading)
+        if len(node.readings) > self.max_readings_per_node:
+            node.readings = node.readings[-self.max_readings_per_node :]
+        node.status = "online"
+        node.updated_at = reading.timestamp
+        return node
+
+    def get_node(self, node_id: str) -> NodeState:
+        try:
+            return self._nodes[node_id]
+        except KeyError as exc:
+            raise KeyError(f"node {node_id!r} not found") from exc
+
+    def list_nodes(self) -> list[NodeState]:
+        return sorted(self._nodes.values(), key=lambda node: node.node_id)
+
+    def mark_stale_nodes(self, now: float | None = None) -> list[NodeState]:
+        now = time.time() if now is None else now
+        stale: list[NodeState] = []
+        for node in self._nodes.values():
+            if node.status == "online" and now - node.updated_at >= self.stale_after_seconds:
+                node.status = "stale"
+                stale.append(node)
+        return stale
+
+
+class DecisionEngine:
+    """Threshold-based local decisions for offline operation."""
+
+    def __init__(
+        self,
+        temp_warning_c: float = 35.0,
+        temp_critical_c: float = 45.0,
+        humidity_warning_pct: float = 75.0,
+    ) -> None:
+        self.temp_warning_c = temp_warning_c
+        self.temp_critical_c = temp_critical_c
+        self.humidity_warning_pct = humidity_warning_pct
+
+    def evaluate(self, reading: SensorReading) -> list[Decision]:
+        decisions: list[Decision] = []
+        if reading.temperature_c is not None:
+            if reading.temperature_c >= self.temp_critical_c:
+                decisions.append(
+                    Decision(
+                        node_id=reading.node_id,
+                        type="temperature_critical",
+                        severity="critical",
+                        action="publish alert and dispatch cooling command",
+                        value=reading.temperature_c,
+                        threshold=self.temp_critical_c,
+                    )
+                )
+            elif reading.temperature_c >= self.temp_warning_c:
+                decisions.append(
+                    Decision(
+                        node_id=reading.node_id,
+                        type="temperature_warning",
+                        severity="warning",
+                        action="publish warning and increase sample rate",
+                        value=reading.temperature_c,
+                        threshold=self.temp_warning_c,
+                    )
+                )
+
+        if reading.humidity_pct is not None and reading.humidity_pct >= self.humidity_warning_pct:
+            decisions.append(
+                Decision(
+                    node_id=reading.node_id,
+                    type="humidity_warning",
+                    severity="warning",
+                    action="publish humidity warning",
+                    value=reading.humidity_pct,
+                    threshold=self.humidity_warning_pct,
+                )
+            )
+        return decisions

--- a/src/nanoclaw/cli.py
+++ b/src/nanoclaw/cli.py
@@ -1,16 +1,23 @@
 """NanoClaw CLI entry point."""
 
+from __future__ import annotations
+
 import argparse
 
+import uvicorn
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="NanoClaw 鈥?L2 Regional Gateway Agent")
+    parser = argparse.ArgumentParser(description="NanoClaw - L2 Regional Gateway Agent")
     parser.add_argument("--port", type=int, default=8000, help="HTTP server port")
     parser.add_argument("--host", default="0.0.0.0", help="HTTP server host")
+    parser.add_argument("--reload", action="store_true", help="Enable uvicorn reload for development")
     args = parser.parse_args()
 
-    print(f"馃 NanoClaw Agent starting on {args.host}:{args.port}...")
-    print("   L2 Regional Gateway ready.")
-    print("   Waiting for L1 edge agent reports...")
+    print(f"NanoClaw Agent starting on {args.host}:{args.port}...")
+    print("L2 regional gateway ready for L1 edge agent reports.")
+    uvicorn.run("nanoclaw.server:app", host=args.host, port=args.port, reload=args.reload)
+
 
 if __name__ == "__main__":
     main()

--- a/src/nanoclaw/server.py
+++ b/src/nanoclaw/server.py
@@ -40,7 +40,7 @@ async def ingest_telemetry(payload: dict[str, Any]) -> dict[str, Any]:
             temperature_c=payload.get("temperature_c"),
             humidity_pct=payload.get("humidity_pct"),
             metrics=payload.get("metrics", {}),
-            timestamp=payload.get("timestamp") or None,
+            timestamp=payload.get("timestamp"),
         )
     except KeyError as exc:
         raise HTTPException(status_code=400, detail="node_id is required") from exc
@@ -53,7 +53,11 @@ async def ingest_telemetry(payload: dict[str, Any]) -> dict[str, Any]:
             metrics=reading.metrics,
         )
 
-    node = aggregator.ingest(reading)
+    try:
+        node = aggregator.ingest(reading)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     decisions = decision_engine.evaluate(reading)
     decision_log.extend(decisions)
 

--- a/src/nanoclaw/server.py
+++ b/src/nanoclaw/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
@@ -16,7 +17,7 @@ app = FastAPI(
 
 aggregator = SensorAggregator()
 decision_engine = DecisionEngine()
-decision_log: list[Decision] = []
+decision_log: deque[Decision] = deque(maxlen=1000)
 
 
 @app.get("/healthz")

--- a/src/nanoclaw/server.py
+++ b/src/nanoclaw/server.py
@@ -1,13 +1,84 @@
-"""NanoClaw FastAPI server 鈥?L2 regional gateway."""
+"""NanoClaw FastAPI server - L2 regional gateway."""
 
-from fastapi import FastAPI
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from nanoclaw.aggregation import Decision, DecisionEngine, SensorAggregator, SensorReading
 
 app = FastAPI(
     title="NanoClaw",
-    description="L2 Regional Gateway Agent 鈥?aggregates data from L1 PicoClaw/MicroClaw nodes",
+    description="L2 regional gateway that aggregates L1 PicoClaw/MicroClaw sensor reports",
     version="0.1.0",
 )
 
+aggregator = SensorAggregator()
+decision_engine = DecisionEngine()
+decision_log: list[Decision] = []
+
+
 @app.get("/healthz")
-async def healthz():
-    return {"status": "ok", "agent": "nanoclaw", "version": "0.1.0"}
+async def healthz() -> dict[str, Any]:
+    aggregator.mark_stale_nodes()
+    return {
+        "status": "ok",
+        "agent": "nanoclaw",
+        "version": "0.1.0",
+        "nodes": len(aggregator.list_nodes()),
+        "decisions": len(decision_log),
+    }
+
+
+@app.post("/api/v1/telemetry", status_code=202)
+async def ingest_telemetry(payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        reading = SensorReading(
+            node_id=str(payload["node_id"]),
+            temperature_c=payload.get("temperature_c"),
+            humidity_pct=payload.get("humidity_pct"),
+            metrics=payload.get("metrics", {}),
+            timestamp=payload.get("timestamp") or None,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=400, detail="node_id is required") from exc
+
+    if reading.timestamp is None:
+        reading = SensorReading(
+            node_id=reading.node_id,
+            temperature_c=reading.temperature_c,
+            humidity_pct=reading.humidity_pct,
+            metrics=reading.metrics,
+        )
+
+    node = aggregator.ingest(reading)
+    decisions = decision_engine.evaluate(reading)
+    decision_log.extend(decisions)
+
+    return {
+        "status": "accepted",
+        "node": node.to_dict(),
+        "decisions": [decision.to_dict() for decision in decisions],
+    }
+
+
+@app.get("/api/v1/nodes")
+async def list_nodes() -> dict[str, Any]:
+    aggregator.mark_stale_nodes()
+    return {"nodes": [node.to_dict() for node in aggregator.list_nodes()]}
+
+
+@app.get("/api/v1/nodes/{node_id}")
+async def get_node(node_id: str) -> dict[str, Any]:
+    aggregator.mark_stale_nodes()
+    try:
+        node = aggregator.get_node(node_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="node not found") from exc
+    return node.to_dict()
+
+
+@app.get("/api/v1/decisions")
+async def list_decisions() -> dict[str, Any]:
+    return {"decisions": [decision.to_dict() for decision in decision_log]}

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -40,6 +40,22 @@ class SensorAggregationTests(unittest.TestCase):
         self.assertEqual([node.node_id for node in stale], ["rack-a1"])
         self.assertEqual(aggregator.get_node("rack-a1").status, "stale")
 
+    def test_ingest_rejects_empty_node_id(self):
+        aggregator = SensorAggregator()
+
+        with self.assertRaises(ValueError):
+            aggregator.ingest(SensorReading(node_id="", temperature_c=25.0, humidity_pct=45.0))
+
+    def test_zero_timestamp_is_preserved(self):
+        aggregator = SensorAggregator()
+
+        node = aggregator.ingest(
+            SensorReading(node_id="rack-a1", temperature_c=25.0, humidity_pct=45.0, timestamp=0.0)
+        )
+
+        self.assertEqual(node.updated_at, 0.0)
+        self.assertEqual(node.latest.timestamp, 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -1,0 +1,45 @@
+import time
+import unittest
+
+from nanoclaw.aggregation import DecisionEngine, SensorAggregator, SensorReading
+
+
+class SensorAggregationTests(unittest.TestCase):
+    def test_ingest_tracks_node_status_and_bounded_history(self):
+        aggregator = SensorAggregator(max_readings_per_node=2)
+        aggregator.ingest(SensorReading(node_id="rack-a1", temperature_c=31.2, humidity_pct=60.0))
+        aggregator.ingest(SensorReading(node_id="rack-a1", temperature_c=32.5, humidity_pct=61.0))
+        aggregator.ingest(SensorReading(node_id="rack-a1", temperature_c=33.1, humidity_pct=62.0))
+
+        node = aggregator.get_node("rack-a1")
+
+        self.assertEqual(node.node_id, "rack-a1")
+        self.assertEqual(node.status, "online")
+        self.assertEqual(len(node.readings), 2)
+        self.assertEqual(node.latest.temperature_c, 33.1)
+        self.assertGreater(node.updated_at, 0)
+
+    def test_decision_engine_flags_threshold_crossings(self):
+        engine = DecisionEngine(temp_warning_c=30.0, temp_critical_c=40.0, humidity_warning_pct=70.0)
+        reading = SensorReading(node_id="rack-a1", temperature_c=41.0, humidity_pct=72.0)
+
+        decisions = engine.evaluate(reading)
+
+        types = {decision.type for decision in decisions}
+        self.assertIn("temperature_critical", types)
+        self.assertIn("humidity_warning", types)
+        self.assertTrue(all(decision.node_id == "rack-a1" for decision in decisions))
+        self.assertTrue(all(decision.action for decision in decisions))
+
+    def test_offline_detection_marks_stale_nodes(self):
+        aggregator = SensorAggregator(stale_after_seconds=1)
+        aggregator.ingest(SensorReading(node_id="rack-a1", temperature_c=25.0, humidity_pct=45.0, timestamp=time.time() - 5))
+
+        stale = aggregator.mark_stale_nodes(now=time.time())
+
+        self.assertEqual([node.node_id for node in stale], ["rack-a1"])
+        self.assertEqual(aggregator.get_node("rack-a1").status, "stale")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -4,6 +4,7 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 README = (ROOT / "README.md").read_text(encoding="utf-8")
 DOCKERFILE = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+SERVER = (ROOT / "src" / "nanoclaw" / "server.py").read_text(encoding="utf-8")
 
 
 class NanoClawDocsTests(unittest.TestCase):
@@ -18,6 +19,10 @@ class NanoClawDocsTests(unittest.TestCase):
         self.assertIn("COPY src/ src/", DOCKERFILE)
         self.assertIn("RUN pip install --no-cache-dir .", DOCKERFILE)
         self.assertIn("uvicorn", DOCKERFILE)
+
+    def test_decision_log_is_bounded(self):
+        self.assertIn("deque(maxlen=1000)", SERVER)
+        self.assertIn("decision_log", SERVER)
 
 
 if __name__ == "__main__":

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,24 @@
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+README = (ROOT / "README.md").read_text(encoding="utf-8")
+DOCKERFILE = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+
+class NanoClawDocsTests(unittest.TestCase):
+    def test_readme_mentions_gateway_and_api(self):
+        self.assertIn("Raspberry Pi Gateway Quick Start", README)
+        self.assertIn("/api/v1/telemetry", README)
+        self.assertIn("Local Decision Engine", README)
+        self.assertIn("temperature_critical", README)
+
+    def test_dockerfile_installs_project_after_copying_src(self):
+        self.assertIn("COPY pyproject.toml README.md ./", DOCKERFILE)
+        self.assertIn("COPY src/ src/", DOCKERFILE)
+        self.assertIn("RUN pip install --no-cache-dir .", DOCKERFILE)
+        self.assertIn("uvicorn", DOCKERFILE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,78 @@
+import asyncio
+from collections import deque
+import importlib
+import sys
+import types
+import unittest
+
+from nanoclaw.aggregation import DecisionEngine, SensorAggregator
+
+
+class FakeFastAPI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get(self, *args, **kwargs):
+        return self._route
+
+    def post(self, *args, **kwargs):
+        return self._route
+
+    @staticmethod
+    def _route(func):
+        return func
+
+
+class FakeHTTPException(Exception):
+    def __init__(self, status_code, detail):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def load_server_module():
+    try:
+        import fastapi  # noqa: F401
+    except ModuleNotFoundError:
+        fake_fastapi = types.ModuleType("fastapi")
+        fake_fastapi.FastAPI = FakeFastAPI
+        fake_fastapi.HTTPException = FakeHTTPException
+        sys.modules["fastapi"] = fake_fastapi
+    return importlib.import_module("nanoclaw.server")
+
+
+class NanoClawServerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = load_server_module()
+
+    def setUp(self):
+        self.server.aggregator = SensorAggregator()
+        self.server.decision_engine = DecisionEngine()
+        self.server.decision_log = deque(maxlen=1000)
+
+    def test_ingest_telemetry_rejects_empty_node_id_as_400(self):
+        with self.assertRaises(self.server.HTTPException) as raised:
+            asyncio.run(self.server.ingest_telemetry({"node_id": ""}))
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertEqual(raised.exception.detail, "node_id is required")
+
+    def test_ingest_telemetry_preserves_zero_timestamp(self):
+        result = asyncio.run(
+            self.server.ingest_telemetry(
+                {
+                    "node_id": "rack-a1",
+                    "temperature_c": 25.0,
+                    "humidity_pct": 45.0,
+                    "timestamp": 0.0,
+                }
+            )
+        )
+
+        self.assertEqual(result["node"]["updated_at"], 0.0)
+        self.assertEqual(result["node"]["latest"]["timestamp"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an in-memory sensor aggregation layer for incoming PicClaw/MicroClaw telemetry
- add a threshold-based offline decision engine for temperature and humidity warnings/criticals
- expose FastAPI endpoints for ingesting telemetry and inspecting nodes/decisions
- wire the CLI to launch the FastAPI app with uvicorn
- fix the Dockerfile install order so the project is copied before `pip install`
- document Raspberry Pi deployment, telemetry topics, and local decision behavior
- add static tests for aggregation, docs, and Docker layout

Closes #2
Closes #3
Closes #4
Closes #5

## Testing
- `python tests/test_aggregation.py`
- `python tests/test_docs.py`
- `python -m compileall src`

## Notes
FastAPI is not installed in the current Windows workspace, so the tests focus on the pure-Python aggregation/decision engine and repository layout. The code itself uses the declared FastAPI/Uvicorn dependencies from `pyproject.toml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new FastAPI ingestion/inspection endpoints with in-memory state and threshold decisioning, which may affect runtime behavior and resource usage under load. Docker/CLI changes are straightforward but impact deployment and startup flow.
> 
> **Overview**
> Adds an in-memory sensor aggregation layer and threshold-based *local decision engine* (`temperature_*`, `humidity_warning`) for incoming L1 node telemetry.
> 
> Exposes new FastAPI endpoints to ingest telemetry (`POST /api/v1/telemetry`) and inspect node state and decision history (`GET /api/v1/nodes`, `GET /api/v1/nodes/{node_id}`, `GET /api/v1/decisions`), and expands `/healthz` to report node/decision counts and mark stale nodes.
> 
> Wires the CLI to launch `uvicorn` (with optional `--reload`), fixes Docker build/install ordering and strengthens the container healthcheck, updates README with gateway quickstart/API docs, and adds unit tests plus lightweight docs/Dockerfile layout checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa869d810cf19477d0ca23542b70eb223a9c4dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->